### PR TITLE
Fix for: SyntaxError: Identifier 'error' has already been declared

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -76,9 +76,9 @@ function getResultMessage(type, data) {
   ${text}
   `
 
-  const error = `
+  const errorMessage = `
   Replacement on '${fileLine}' FAILED:
-  ${error.message}
+  ${error?.message}
   `
 
   const messages = {
@@ -86,7 +86,7 @@ function getResultMessage(type, data) {
     noChanges,
     lineCleared,
     changed,
-    error
+    errorMessage
   }
 
   return messages[type]


### PR DESCRIPTION
Name clashes with 'const error' variable and stops executing. I changed name to errorMessage.
If error was not provided it throws another error on the line 'error.message'. I added optional to fix this.